### PR TITLE
Fix URLs to BazingaExposeTranslationBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This bundle is `g11n` compatible.(i18n + L10n)
 ## Prerequisite
 
 * The JavaScript framework [jQuery](http://jquery.com/) is recommended.
-* [BazingaExposeTranslationBundle](https://github.com/Bazinga/BazingaExposeTranslationBundle/blob/master/README.markdown) is mandatory. This bundle compute and translate messages in javascript.
+* [BazingaExposeTranslationBundle](https://github.com/willdurand/BazingaExposeTranslationBundle) is mandatory. This bundle compute and translate messages in javascript.
 
 ## Installation
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -3,7 +3,7 @@ Installation
 
 ## Step 1: Install BazingaExposeTranslationBundle
 
-Please follow the steps given [here](https://github.com/Bazinga/BazingaExposeTranslationBundle/blob/master/README.markdown) to install this bundle.
+Please follow the steps given [here](https://github.com/willdurand/BazingaExposeTranslationBundle/blob/master/README.markdown) to install this bundle.
 
 ## Step 2: Download JsFormValidationBundle
 


### PR DESCRIPTION
Old repository doesn't exist anymore -- this seems to be the new one
