### PR TITLE
Fixed syntax error when there are more than one constraint

### DIFF
--- a/Resources/views/JsFormValidation.js.twig
+++ b/Resources/views/JsFormValidation.js.twig
@@ -109,7 +109,7 @@ var jsfv = new function () {
             jsfv.onEvent('{{ fieldName }}', 'blur', jsfv.check_{{ fieldName }});
 {% endfor %}
 {% endif %}
-        }
+        }{% if not loop.last %},{% endif %}
 {% endfor %}
     };
 }


### PR DESCRIPTION
Hi,

when I wanted to use the bundle in form with more than one constraint, there was a syntax error in the generated validation script.

Attached fix resolves the issue.

Regards,
Jan
