### PR TITLE
New 'change' check mode

### DIFF
--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -27,7 +27,8 @@ class APYJsFormValidationExtension extends Extension
 
         $container->setParameter('apy_js_form_validation.enabled', $config['enabled']);
         $container->setParameter('apy_js_form_validation.yui_js', $config['yui_js']);
-        $container->setParameter('apy_js_form_validation.check_mode', $config['check_mode']);
+        $container->setParameter('apy_js_form_validation.check_mode', isset($config['check_mode'])) ? $config['check_mode'] : null;
+        $container->setParameter('apy_js_form_validation.check_modes', $config['check_modes']);
         $container->setParameter('apy_js_form_validation.script_directory', $config['script_directory']);
         $container->setParameter('apy_js_form_validation.validation_bundle', $config['validation_bundle']);
         $container->setParameter('apy_js_form_validation.javascript_framework', $config['javascript_framework']);
@@ -48,10 +49,18 @@ class APYJsFormValidationExtension extends Extension
                     ->booleanNode('enabled')->defaultValue(true)->end()
                     ->booleanNode('yui_js')->defaultValue(false)->end()
                     ->scalarNode('check_mode')
-                        ->defaultValue('both')
                         ->validate()
                             ->ifNotInArray(array('submit', 'blur', 'both'))
                             ->thenInvalid('The %s mode is not supported')
+                        ->end()
+                    ->end()
+                    ->arrayNode('check_modes')
+                        ->defaultValue(array('submit', 'blur'))
+                        ->prototype('scalar')
+                            ->validate()
+                                ->ifNotInArray(array('submit', 'blur', 'change'))
+                                ->thenInvalid('%s is not a valid bundle.')
+                            ->end()
                         ->end()
                     ->end()
                     ->scalarNode('validation_bundle')->defaultValue('APYJsFormValidationBundle')->end()

--- a/Generator/FormValidationScriptGenerator.php
+++ b/Generator/FormValidationScriptGenerator.php
@@ -364,9 +364,14 @@ class FormValidationScriptGenerator
             $dispatcher->dispatch(JsfvEvents::postProcess, $postProcessEvent);
 
             // Retrieve validation mode from configuration
-            $check_modes = array('submit' => false, 'blur' => false);
+            $check_modes = array('submit' => false, 'blur' => false, 'change' => false);
             switch ($this->container->getParameter('apy_js_form_validation.check_mode')) {
                 default:
+                    // check_mode not set, look into check_modes:
+                    foreach ($this->container->getParameter('apy_js_form_validation.check_modes') as $check_mode) {
+                        $check_modes[$check_mode] = true;
+                    }
+                    break;
                 case 'submit':
                     $check_modes['submit'] = true;
                     break;

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -7,7 +7,8 @@ Reference
 apy_js_form_validation:
     enabled: true
     yui_js: false
-    check_mode: both
+    check_mode: false
+    check_modes: [submit, blur]
     javascript_framework: jquery
     validation_bundle: APYJsFormValidationBundle
     script_directory: bundles/jsformvalidation/js/
@@ -19,10 +20,15 @@ apy_js_form_validation:
 
 * `yui_js` is optional (Default: `false`). Set to `true` enable yui compressor. `yui_js` assetic filter have to be defined.
 
-* `check_mode` is optional (Default: `both`). Mode of the validation.
+* `check_mode` *DEPRECATED* is optional (Default: `false`). Mode of the validation.
 Set to `submit` enable a validation of a form on the submit action.
 Set to `blur` enable a validation of a field of a form when the field lost the focus.
 Set to `both` enable both validations of a form.
+
+* `check_modes` is optional (Default: [submit, change]). Modes of the validation.
+Add `submit` to enable a validation of a form on the submit action.
+Add `blur` to enable a validation of a field of a form when the field lost the focus.
+Add `change` to enable a validation of a field of a form when the field is changed. This will behave mostly the same as `blur`, but will avoid race condition and false validation errors to appear with widgets like jQueryUI datepicker.
 
 * `javascript_framework` is recommended (Default: `jquery`). Javascript framework used by the validation script.
 Choices: `jquery`, `mootools`, `prototype`, `yui3`, `dojo`, `zepto` or `extjs`

--- a/Resources/views/JsFormValidation.js.twig
+++ b/Resources/views/JsFormValidation.js.twig
@@ -141,6 +141,13 @@ var jsfv = new function () {
             jsfv.onEvent('{{ fieldName }}', 'blur', jsfv.check_{{ fieldName }});
 {% endfor %}
 {% endif %}
+
+{% if check_modes.change %}
+            // On change checks
+{% for fieldName, constraints in fieldConstraints %}
+            jsfv.onEvent('{{ fieldName }}', 'change', jsfv.check_{{ fieldName }});
+{% endfor %}
+{% endif %}
         }
     };
 }


### PR DESCRIPTION
I found a problem with 'blur' checks with jQueryUI datepicker widget field: field loses it's focus before widget updates it's value and validation error displayed, though value is correct.
I've added a new 'change' check - it works nice with such widgets and behaves almost the same as 'blur'.
I maintained BC, but had to introduce a new array option 'check_mode_s_' spelled almost the same as former 'check_mode' - that can be confusing...
