### PR TITLE
New 'change' check mode + new 'check_modes' option

### DIFF
--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -25,6 +25,12 @@ class APYJsFormValidationExtension extends Extension
         $processor = new Processor();
         $config = $processor->process($this->getConfigTree(), $configs);
 
+        if (isset($config['check_mode'])) {
+            // throw an informative message about option removal
+            // TODO: remove this in some future
+            throw new \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException("Option 'check_mode' is removed, use a new 'check_modes' (note trailing 's') option instead. Refer to bundle documentation for details.");
+        }
+
         $container->setParameter('apy_js_form_validation.enabled', $config['enabled']);
         $container->setParameter('apy_js_form_validation.yui_js', $config['yui_js']);
         $container->setParameter('apy_js_form_validation.check_modes', $config['check_modes']);
@@ -47,6 +53,10 @@ class APYJsFormValidationExtension extends Extension
                 ->children()
                     ->booleanNode('enabled')->defaultValue(true)->end()
                     ->booleanNode('yui_js')->defaultValue(false)->end()
+                    // Symfony will throw non-informative exception on 'check_mode' option is not present
+                    // in a tree before our explanatory exception can be thrown.
+                    // TODO: remove this in some future
+                    ->scalarNode('check_mode')->end()
                     ->arrayNode('check_modes')
                         ->defaultValue(array('submit', 'blur'))
                         ->prototype('scalar')

--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -27,7 +27,6 @@ class APYJsFormValidationExtension extends Extension
 
         $container->setParameter('apy_js_form_validation.enabled', $config['enabled']);
         $container->setParameter('apy_js_form_validation.yui_js', $config['yui_js']);
-        $container->setParameter('apy_js_form_validation.check_mode', isset($config['check_mode'])) ? $config['check_mode'] : null;
         $container->setParameter('apy_js_form_validation.check_modes', $config['check_modes']);
         $container->setParameter('apy_js_form_validation.script_directory', $config['script_directory']);
         $container->setParameter('apy_js_form_validation.validation_bundle', $config['validation_bundle']);
@@ -48,18 +47,12 @@ class APYJsFormValidationExtension extends Extension
                 ->children()
                     ->booleanNode('enabled')->defaultValue(true)->end()
                     ->booleanNode('yui_js')->defaultValue(false)->end()
-                    ->scalarNode('check_mode')
-                        ->validate()
-                            ->ifNotInArray(array('submit', 'blur', 'both'))
-                            ->thenInvalid('The %s mode is not supported')
-                        ->end()
-                    ->end()
                     ->arrayNode('check_modes')
                         ->defaultValue(array('submit', 'blur'))
                         ->prototype('scalar')
                             ->validate()
                                 ->ifNotInArray(array('submit', 'blur', 'change'))
-                                ->thenInvalid('%s is not a valid bundle.')
+                                ->thenInvalid('%s is not a valid validation mode. Refer to bundle documentation.')
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class APYJsFormValidationExtension extends Extension
 {
@@ -28,7 +29,7 @@ class APYJsFormValidationExtension extends Extension
         if (isset($config['check_mode'])) {
             // throw an informative message about option removal
             // TODO: remove this in some future
-            throw new \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException("Option 'check_mode' is removed, use a new 'check_modes' (note trailing 's') option instead. Refer to bundle documentation for details.");
+            throw new InvalidConfigurationException("Option 'check_mode' is removed, use a new 'check_modes' (note trailing 's') option instead. Refer to bundle documentation for details.");
         }
 
         $container->setParameter('apy_js_form_validation.enabled', $config['enabled']);

--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -53,8 +53,8 @@ class APYJsFormValidationExtension extends Extension
                 ->children()
                     ->booleanNode('enabled')->defaultValue(true)->end()
                     ->booleanNode('yui_js')->defaultValue(false)->end()
-                    // Symfony will throw non-informative exception on 'check_mode' option is not present
-                    // in a tree before our explanatory exception can be thrown.
+                    // Without this line Symfony will throw non-informative exception on 'check_mode'
+                    // option is not present in a tree before our explanatory exception can be thrown.
                     // TODO: remove this in some future
                     ->scalarNode('check_mode')->end()
                     ->arrayNode('check_modes')

--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -27,7 +27,8 @@ class APYJsFormValidationExtension extends Extension
 
         $container->setParameter('apy_js_form_validation.enabled', $config['enabled']);
         $container->setParameter('apy_js_form_validation.yui_js', $config['yui_js']);
-        $container->setParameter('apy_js_form_validation.check_mode', $config['check_mode']);
+        $container->setParameter('apy_js_form_validation.check_mode', isset($config['check_mode'])) ? $config['check_mode'] : null;
+        $container->setParameter('apy_js_form_validation.check_modes', $config['check_modes']);
         $container->setParameter('apy_js_form_validation.script_directory', $config['script_directory']);
         $container->setParameter('apy_js_form_validation.validation_bundle', $config['validation_bundle']);
         $container->setParameter('apy_js_form_validation.javascript_framework', $config['javascript_framework']);
@@ -48,10 +49,18 @@ class APYJsFormValidationExtension extends Extension
                     ->booleanNode('enabled')->defaultValue(true)->end()
                     ->booleanNode('yui_js')->defaultValue(false)->end()
                     ->scalarNode('check_mode')
-                        ->defaultValue('both')
                         ->validate()
                             ->ifNotInArray(array('submit', 'blur', 'both'))
                             ->thenInvalid('The %s mode is not supported')
+                        ->end()
+                    ->end()
+                    ->arrayNode('check_modes')
+                        ->defaultValue(array('submit', 'blur'))
+                        ->prototype('scalar')
+                            ->validate()
+                                ->ifNotInArray(array('submit', 'blur', 'change'))
+                                ->thenInvalid('%s is not a valid bundle.')
+                            ->end()
                         ->end()
                     ->end()
                     ->scalarNode('validation_bundle')->defaultValue('APYJsFormValidationBundle')->end()

--- a/Generator/FormValidationScriptGenerator.php
+++ b/Generator/FormValidationScriptGenerator.php
@@ -365,22 +365,8 @@ class FormValidationScriptGenerator
 
             // Retrieve validation mode from configuration
             $check_modes = array('submit' => false, 'blur' => false, 'change' => false);
-            switch ($this->container->getParameter('apy_js_form_validation.check_mode')) {
-                default:
-                    // check_mode not set, look into check_modes:
-                    foreach ($this->container->getParameter('apy_js_form_validation.check_modes') as $check_mode) {
-                        $check_modes[$check_mode] = true;
-                    }
-                    break;
-                case 'submit':
-                    $check_modes['submit'] = true;
-                    break;
-                case 'blur':
-                    $check_modes['blur'] = true;
-                    break;
-                case 'both':
-                    $check_modes = array('submit' => true, 'blur' => true);
-                    break;
+            foreach ($this->container->getParameter('apy_js_form_validation.check_modes') as $check_mode) {
+                $check_modes[$check_mode] = true;
             }
 
             // Render the validation script

--- a/Generator/FormValidationScriptGenerator.php
+++ b/Generator/FormValidationScriptGenerator.php
@@ -364,9 +364,14 @@ class FormValidationScriptGenerator
             $dispatcher->dispatch(JsfvEvents::postProcess, $postProcessEvent);
 
             // Retrieve validation mode from configuration
-            $check_modes = array('submit' => false, 'blur' => false);
+            $check_modes = array('submit' => false, 'blur' => false, 'change' => false);
             switch ($this->container->getParameter('apy_js_form_validation.check_mode')) {
                 default:
+                    // check_mode not set, look into check_modes:
+                    foreach ($this->container->getParameter('apy_js_form_validation.check_modes') as $check_mode) {
+                        $check_modes[$check_mode] = true;
+                    }
+                    break;
                 case 'submit':
                     $check_modes['submit'] = true;
                     break;

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -7,7 +7,8 @@ Reference
 apy_js_form_validation:
     enabled: true
     yui_js: false
-    check_mode: both
+    check_mode: false
+    check_modes: [submit, blur]
     javascript_framework: jquery
     validation_bundle: APYJsFormValidationBundle
     script_directory: bundles/jsformvalidation/js/
@@ -19,10 +20,15 @@ apy_js_form_validation:
 
 * `yui_js` is optional (Default: `false`). Set to `true` enable yui compressor. `yui_js` assetic filter have to be defined.
 
-* `check_mode` is optional (Default: `both`). Mode of the validation.
+* `check_mode` *DEPRECATED* is optional (Default: `false`). Mode of the validation.
 Set to `submit` enable a validation of a form on the submit action.
 Set to `blur` enable a validation of a field of a form when the field lost the focus.
 Set to `both` enable both validations of a form.
+
+* `check_modes` is optional (Default: [submit, change]). Modes of the validation.
+Add `submit` to enable a validation of a form on the submit action.
+Add `blur` to enable a validation of a field of a form when the field lost the focus.
+Add `change` to enable a validation of a field of a form when the field is changed. This will behave mostly the same as `blur`, but will avoid race condition and false validation errors to appear with widgets like jQueryUI datepicker.
 
 * `javascript_framework` is recommended (Default: `jquery`). Javascript framework used by the validation script.
 Choices: `jquery`, `mootools`, `prototype`, `yui3`, `dojo`, `zepto` or `extjs`

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -7,7 +7,6 @@ Reference
 apy_js_form_validation:
     enabled: true
     yui_js: false
-    check_mode: false
     check_modes: [submit, blur]
     javascript_framework: jquery
     validation_bundle: APYJsFormValidationBundle
@@ -20,7 +19,7 @@ apy_js_form_validation:
 
 * `yui_js` is optional (Default: `false`). Set to `true` enable yui compressor. `yui_js` assetic filter have to be defined.
 
-* `check_mode` *DEPRECATED* use `check_modes` instead.
+* `check_mode` **DEPRECATED** use `check_modes` instead.
 
 * `check_modes` is optional (Default: ["submit", "blur"]). Modes of the validation.
 Add `submit` to enable a validation of a form on the submit action.

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -20,12 +20,9 @@ apy_js_form_validation:
 
 * `yui_js` is optional (Default: `false`). Set to `true` enable yui compressor. `yui_js` assetic filter have to be defined.
 
-* `check_mode` *DEPRECATED* is optional (Default: `false`). Mode of the validation.
-Set to `submit` enable a validation of a form on the submit action.
-Set to `blur` enable a validation of a field of a form when the field lost the focus.
-Set to `both` enable both validations of a form.
+* `check_mode` *DEPRECATED* use `check_modes` instead.
 
-* `check_modes` is optional (Default: [submit, change]). Modes of the validation.
+* `check_modes` is optional (Default: ["submit", "blur"]). Modes of the validation.
 Add `submit` to enable a validation of a form on the submit action.
 Add `blur` to enable a validation of a field of a form when the field lost the focus.
 Add `change` to enable a validation of a field of a form when the field is changed. This will behave mostly the same as `blur`, but will avoid race condition and false validation errors to appear with widgets like jQueryUI datepicker.

--- a/Resources/views/JsFormValidation.js.twig
+++ b/Resources/views/JsFormValidation.js.twig
@@ -141,6 +141,13 @@ var jsfv = new function () {
             jsfv.onEvent('{{ fieldName }}', 'blur', jsfv.check_{{ fieldName }});
 {% endfor %}
 {% endif %}
+
+{% if check_modes.change %}
+            // On change checks
+{% for fieldName, constraints in fieldConstraints %}
+            jsfv.onEvent('{{ fieldName }}', 'change', jsfv.check_{{ fieldName }});
+{% endfor %}
+{% endif %}
         }
     };
 }


### PR DESCRIPTION
Completely removed `check_mode` Scalar option.
Introduced a `check_modes` Array option for replacement.
Introduced a `change` validation mode.
Updated docs.

P.S. Did no handling for using former `check_mode` option as Symfony will throw an InvalidConfigurationException itself. If there's need for more informative exception message like 'This option deprecated, use a new one instead', I can code and submit it in a new PR.
