### PR TITLE
Update symfony version for 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": "2.1.*",
+        "symfony/symfony": ">=2.1,<2.3-dev",
         "willdurand/expose-translation-bundle": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
Documentation state that the bundle is compatible with Symfony 2.1
and upper, but we can't install it with Symfony 2.2.
