### PR TITLE
Add plural for Length Validator

### DIFF
--- a/Resources/views/Constraints/LengthValidator.js.twig
+++ b/Resources/views/Constraints/LengthValidator.js.twig
@@ -12,14 +12,14 @@ function Length(field, params)
 	    params['min'] !== undefined && params['max'] !== undefined && 
 	    params.min == params.max) {
 	    if (value.length != parseInt(params.min)) {
-    		return getComputeMessage(params.exactMessage, { 'min' : params.min, 'max' : params.max } );
+    		return getComputeMessage(params.exactMessage, { 'limit' : params.min }, params.min);
 	    }
     } else {
 	    if (params['min'] !== undefined && value.length < parseInt(params.min)) {
-	        return getComputeMessage(params.minMessage, { 'min' : params.min } );
+	        return getComputeMessage(params.minMessage, { 'limit' : params.min }, params.min);
 	    }
 	    if (params['max'] !== undefined && value.length > parseInt(params.max)) {
-	        return getComputeMessage(params.maxMessage, { 'max' : params.max } );
+	        return getComputeMessage(params.maxMessage, { 'limit' : params.max }, params.max);
 	    }
     }
 


### PR DESCRIPTION
As specified inside the Symfony\Component\Validator\Constraints\Length class, messages are pluralizable sentences.

Without this code "This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less." is render
