### PR TITLE
Functional for embedded symfony2 form. Add new parameter to config bundle.

### DIFF
--- a/DependencyInjection/APYJsFormValidationExtension.php
+++ b/DependencyInjection/APYJsFormValidationExtension.php
@@ -40,6 +40,7 @@ class APYJsFormValidationExtension extends Extension
         $container->setParameter('apy_js_form_validation.javascript_framework', $config['javascript_framework']);
         $container->setParameter('apy_js_form_validation.warmer_routes', $config['warmer_routes']);
         $container->setParameter('apy_js_form_validation.identifier_field', $config['identifier_field']);
+        $container->setParameter('apy_js_form_validation.translation_group', $config['translation_group']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
@@ -70,6 +71,7 @@ class APYJsFormValidationExtension extends Extension
                     ->scalarNode('validation_bundle')->defaultValue('APYJsFormValidationBundle')->end()
                     ->scalarNode('javascript_framework')->defaultValue('jquery')->end()
                     ->scalarNode('script_directory')->defaultValue('bundles/jsformvalidation/js/')->end()
+                    ->scalarNode('translation_group')->defaultValue('validators')->end()
                     ->arrayNode('warmer_routes')
                         ->canBeUnset()
                         ->prototype('scalar')->end()

--- a/Generator/AnnotationLoader.php
+++ b/Generator/AnnotationLoader.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\GroupSequenceProvider;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader as Loader;
 
-class AnnotationLoaderApy extends Loader
+class AnnotationLoader extends Loader
 {
     /**
      * {@inheritDoc}

--- a/Generator/AnnotationLoaderApy.php
+++ b/Generator/AnnotationLoaderApy.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace APY\JsFormValidationBundle\Generator;
+
+use Doctrine\Common\Annotations\Reader;
+use Symfony\Component\Validator\Exception\MappingException;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\GroupSequenceProvider;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader as Loader;
+
+class AnnotationLoaderApy extends Loader
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function loadClassMetadata(ClassMetadata $metadata)
+    {
+        $reflClass = $metadata->getReflectionClass();
+        $className = $reflClass->name;
+        $loaded = false;
+
+        foreach ($this->reader->getClassAnnotations($reflClass) as $constraint) {
+            if ($constraint instanceof GroupSequence) {
+                $metadata->setGroupSequence($constraint->groups);
+            } elseif ($constraint instanceof GroupSequenceProvider) {
+                $metadata->setGroupSequenceProvider(true);
+            } elseif ($constraint instanceof Constraint) {
+                $metadata->addConstraint($constraint);
+            }
+
+            $loaded = true;
+        }
+
+        foreach ($reflClass->getProperties() as $property) {
+            foreach ($this->reader->getPropertyAnnotations($property) as $constraint) {
+                if ($constraint instanceof Constraint) {
+                    $metadata->addPropertyConstraint($property->name, $constraint);
+                }
+
+                $loaded = true;
+            }
+        }
+
+        foreach ($reflClass->getMethods() as $method) {
+            foreach ($this->reader->getMethodAnnotations($method) as $constraint) {
+                if ($constraint instanceof Constraint) {
+                    if (preg_match('/^(get|is)(.+)$/i', $method->name, $matches)) {
+                        $metadata->addGetterConstraint(lcfirst($matches[2]), $constraint);
+                    } else {
+                        throw new MappingException(sprintf('The constraint on "%s::%s" cannot be added. Constraints can only be added on methods beginning with "get" or "is".', $className, $method->name));
+                    }
+                }
+
+                $loaded = true;
+            }
+        }
+
+        return $loaded;
+    }
+}

--- a/Generator/FormValidationScriptGenerator.php
+++ b/Generator/FormValidationScriptGenerator.php
@@ -372,11 +372,15 @@ class FormValidationScriptGenerator
                             //We need to know entity class for the field which is applied by UniqueEntity constraint
                             if ($constraintName == 'UniqueEntity' && !empty($formFieldN->parent)) {
                                 $entity = isset($formFieldN->parent->vars['value']) ?
-                                    $formField->parent->vars['value'] : null;
+                                    $formFieldN->parent->vars['value'] : null;
+                                if(isset($formView->children[$this->getParameter('identifier_field')])) {
+                                    $id = json_encode($formView->children[$this->getParameter('identifier_field')]->vars['id']);
+                                } else {
+                                    $id = json_encode($formFieldN->vars['id']);
+                                }
                                 $constraintParameters += array(
                                     'entity:' . json_encode(get_class($entity)),
-                                    'identifier_field_id:'.
-                                        json_encode($formView->children[$this->getParameter('identifier_field')]->vars['id']),
+                                    'identifier_field_id:'. $id,
                                 );
                             }
                             foreach ($constraintProperties as $variable => $value) {

--- a/Generator/FormValidationScriptGenerator.php
+++ b/Generator/FormValidationScriptGenerator.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormView;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
-use APY\JsFormValidationBundle\Generator\AnnotationLoaderApy as AnnotationLoader;
+use APY\JsFormValidationBundle\Generator\AnnotationLoader;
 use Assetic\Filter\Yui\JsCompressorFilter;
 use Assetic\Asset\AssetCollection;
 

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -13,6 +13,7 @@ apy_js_form_validation:
     script_directory: bundles/jsformvalidation/js/
     warmer_routes: [route1,route2]
     identifier_field: jsfv_identifier
+    translation_group: validators
 ```
 
 * `enabled` is optional (Default: `true`). Set to `false` disable all javascript form validations if you use the Twig function.
@@ -45,3 +46,6 @@ Here is a framework template of a the common script for validation.
 * `identifier_field` is optional (Default: `jsfv_identifier`).
 Defines the name of the hidden field which serves to convey the primary identifier value for UniqueEntity constraint request.
 This value will be ignored when entity is updated.
+
+* `translation_group` is optional (Default: `validators`)
+It's parameter used for translate function in js look like: Translator.get('{{ 'translation_group' }}':'+key, placeholders, number);

--- a/Resources/views/JsFormValidation.js.twig
+++ b/Resources/views/JsFormValidation.js.twig
@@ -14,11 +14,11 @@ var jsfv = new function () {
         Translator.placeHolderPrefix = '{{ '{{' }} ';
         Translator.placeHolderSuffix = ' {{ '}}' }}';
         // Default translations
-        if (!Translator.has('validators:'+key)) {
-            Translator.add('validators:'+key, key);
+        if (!Translator.has('{{ translation_group }}:'+key)) {
+            Translator.add('{{ translation_group }}:'+key, key);
         }
 
-        return Translator.get('validators:'+key, placeholders, number);
+        return Translator.get('{{ translation_group }}:'+key, placeholders, number);
     }
 
     function isNotDefined(value) {

--- a/Tests/Functional/TestBundle/Controller/DefaultController.php
+++ b/Tests/Functional/TestBundle/Controller/DefaultController.php
@@ -25,6 +25,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use APY\JsFormValidationBundle\Tests\Functional\TestBundle\Form\Type\UserProfileType;
 
 /**
  * @author    Vitaliy Demidov   <zend@i.ua>
@@ -104,6 +105,19 @@ class DefaultController extends Controller
             'form' => $form->createView(),
             'form2' => $form2->createView(),
             'form3' => $form3->createView(),
+        );
+    }
+
+    /**
+     * @Route("/embedded-form", name = "embedded_form")
+     * @Template
+     */
+    public function embeddedFormAction()
+    {
+        $form = $this->createForm(new UserProfileType());
+
+        return array(
+            'form' => $form->createView(),
         );
     }
 }

--- a/Tests/Functional/TestBundle/Entity/Profile.php
+++ b/Tests/Functional/TestBundle/Entity/Profile.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the JsFormValidationBundle.
+ *
+ * (c) Abhoryo <abhoryo@free.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace APY\JsFormValidationBundle\Tests\Functional\TestBundle\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Product Entity which is used for testing purposes
+ *
+ * @author Alexandr Sharamko <alexandr.sharamko@gmail.com>
+ */
+class Profile
+{
+    /**
+     * @Assert\NotBlank(message = "Name should not be blank.")
+     * @Assert\Regex(pattern="/^[a-z \-]+$/i", message = "Name should contain only letters.")
+     */
+    protected $name;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+}

--- a/Tests/Functional/TestBundle/Form/Type/ProfileType.php
+++ b/Tests/Functional/TestBundle/Form/Type/ProfileType.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the JsFormValidationBundle.
+ *
+ * (c) Abhoryo <abhoryo@free.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace APY\JsFormValidationBundle\Tests\Functional\TestBundle\Form\Type;
+
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Alexandr Sharamko <alexandr.sharamko@gmail.com>
+ */
+class ProfileType extends AbstractType
+{
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see Symfony\Component\Form.AbstractType::setDefaultOptions()
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'APY\JsFormValidationBundle\Tests\Functional\TestBundle\Entity\Profile',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see Symfony\Component\Form.FormTypeInterface::getName()
+     */
+    public function getName()
+    {
+        return 'profile';
+    }
+}

--- a/Tests/Functional/TestBundle/Form/Type/UserProfileType.php
+++ b/Tests/Functional/TestBundle/Form/Type/UserProfileType.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the JsFormValidationBundle.
+ *
+ * (c) Abhoryo <abhoryo@free.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace APY\JsFormValidationBundle\Tests\Functional\TestBundle\Form\Type;
+
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Alexandr Sharamko <alexandr.sharamko@gmail.com>
+ */
+class UserProfileType extends AbstractType
+{
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'user',
+            new UserType()
+        );
+        $builder->add(
+            'profile',
+            new ProfileType()
+        );
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(
+            array(
+                'csrf_protection'    => true,
+                'csrf_field_name'    => '_token',
+                'cascade_validation' => true
+            )
+        );
+    }
+
+    public function getName()
+    {
+        return 'user_profile';
+    }
+}

--- a/Tests/Functional/TestBundle/Resources/views/Default/embeddedForm.html.twig
+++ b/Tests/Functional/TestBundle/Resources/views/Default/embeddedForm.html.twig
@@ -1,0 +1,15 @@
+{% extends "::base.html.twig" %}
+
+{% block body %}
+    <form id="{{ form.vars.id }}" action="{{ path("entity_annotation_form") }}"
+        method="post" class="form-horizontal" {{ form_enctype(form) }}>
+        <fieldset>
+            {{ form_errors(form) }}
+            {{ form_rest(form) }}
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary">Save</button>
+            </div>
+        </fieldset>
+    </form>
+    {{ JSFV(form) }}
+{% endblock %}

--- a/Twig/Extension/JsFormValidationTwigExtension.php
+++ b/Twig/Extension/JsFormValidationTwigExtension.php
@@ -55,7 +55,6 @@ class JsFormValidationTwigExtension extends \Twig_Extension
             // Generate the script
             $jsfvGenerator = $this->container->get('jsfv');
             $scriptFile = $jsfvGenerator->generate($formView);
-
             if ($getScriptPath) {
                 return $scriptFile;
             } else {


### PR DESCRIPTION
Implements functionality for symfony2 embedded form. Creates fix for for the annotation reader as it didn't read extended class annotation. Add new parameter to config bundle.

Example:

```
public function buildForm(FormBuilderInterface $builder, array $options)
{
    $builder->add(
        'form1',
        new FormFirstType()
    );
    $builder->add(
        'form2',
        new FormSecondType($this->user)
    );
}
```
