### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
-#2012-08-16
+# 2012-08-16
 - [Tests] Covered uniqueEntity
 
-#2012-08-16
+# 2012-08-16
 - Implemented phpunit tests. Fixed composer for travis integration.
 - Fixed issue #13. Fields with property_path = false must be excluded from validation.
 - Fixed issue #16. No need to supply second parameter to createForm controller function.
@@ -11,32 +11,32 @@
 	Before:
 		{{ JSFV(form, true) }} has returned  /bundle/jsformvalidation/js/myRoute.js
 
-#2012-08-12
+# 2012-08-12
 - Implemented client-side validation of simple forms which are built manually.
 
-#2012-08-10
+# 2012-08-10
 - Added CheckMX support for Email Constraint
 - Added getJsFormElementValue(field) Twig Extention
 - Changed interface of JS calls. Field object is passed instead of value by default.
 
-#2012-08-06
+# 2012-08-06
 - Unique Entity support has been implemented (jquery framework only)
 - Implemented validation of the constraints which are based on method of the entity clas
 
-#2012-08-04
+# 2012-08-04
 - Version 2.1 has been mastered.
 - Fix issue #8 Symfony 2.1 compability
 
-#2011-12-05
+# 2011-12-05
 - Dispatch events before and after processing constraints of a form
 - Manage validation groups with an event listener
 - Manage repeated field
 - Include the asset helper function
 - Doc for events
 
-#2011-12-01
+# 2011-12-01
 - New assets warmer system. Now, define routes in configuraiton instead of a list of parameters
 - fix isIPv6_no_res function in IpValidator
 
-#2011-11-29
+# 2011-11-29
 - Search for the first parent form

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#This Bundle is no longer maintained.  
+# This Bundle is no longer maintained.  
 Over the years, the structure of Symfony forms has evolved and this bundle has tried to follow its evolution without changing its own structure. However, this old structure is not adapted to new versions of Symfony.  
 Instead of starting from scratch and generate code similar to another Bundle, I'd rather advise you to use this other Bundle.  
 
@@ -14,7 +14,7 @@ It was a real pleasure to offer this kind of bundle for early versions of Symfon
 
 ---
 
-##Getting Started With JsFormValidationBundle
+## Getting Started With JsFormValidationBundle
 
 **Version**: 2.1
 [![Build Status](https://secure.travis-ci.org/Abhoryo/APYJsFormValidationBundle.png?branch=master)](http://travis-ci.org/Abhoryo/APYJsFormValidationBundle)

--- a/Resources/doc/reporting_issue.md
+++ b/Resources/doc/reporting_issue.md
@@ -52,7 +52,7 @@ OK (4 tests, 50 assertions)
 ```
 
 
-###PHPUnit
+### PHPUnit
 To run the Symfony2 test suite, install PHPUnit 3.5.11 or later:
 
 ```bash


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
